### PR TITLE
Controlling for different Mac-v-Win default encoding schemas when reading csv files

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -1,1 +1,803 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": ["# CSV"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Introduction\n", "\n", "In this lesson we will cover the CSV (comma-separated values) data format, one of the most simple and popular data serialization formats used in data science.\n", "\n", "## Objectives\n", "\n", "You will be able to:\n", "\n", "* Describe features of the CSV format and the Python `csv` module\n", "* Use Python to read and parse data from CSV files\n", "* Interpret the schemas of CSV files"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## CSV Format\n", "\n", "The full name for this data format is \"comma-separated values\", but it is conventionally referred to by the shorthand \"CSV\"\n", "\n", "At a high level, this format is designed to contain tabular data (data represented by rows and columns), where each line of the file is a row, and each column of data within that row is separated by a comma.\n", "\n", "CSV is a **plain text**, **delimited** format, meaning its contents are essentially just strings with a specified structure. You can visually inspect the contents of plain text files using general-purpose text editing tools such as Vim, VS Code, or Notepad.  (This is in contrast to formats like images or SQLite databases, which contain encoded bytes that require specific tools to read.)\n", "\n", "Because of this, we can start digging in to how the CSV *format* works without actually using any CSV *files*. Instead we'll just start with some Python strings.\n", "\n", "Let's say we have this dataset representing the 100 meter dash times for 4 high school athletes across 3 track meets:\n", "\n", "| Meet 1 | Meet 2 | Meet 3 |\n", "| ------ | ------ | ------ |\n", "| 13.10  | 13.59  | 13.44  |\n", "| 13.93  | 13.85  | 13.47  |\n", "| 14.12  | 14.41  | 13.89  |\n", "| 14.42  | 13.55  | 13.43  |\n", "\n", "If we wanted to represent that dataset in Python, we might do something like this:"]}, {"cell_type": "code", "execution_count": 1, "metadata": {}, "outputs": [{"data": {"text/plain": ["[[13.1, 13.59, 13.44],\n", " [13.93, 13.85, 13.47],\n", " [14.12, 14.41, 13.89],\n", " [14.42, 13.55, 13.43]]"]}, "execution_count": 1, "metadata": {}, "output_type": "execute_result"}], "source": ["track_times = [\n", "    [13.10, 13.59, 13.44],\n", "    [13.93, 13.85, 13.47],\n", "    [14.12, 14.41, 13.89],\n", "    [14.42, 13.55, 13.43]\n", "]\n", "track_times"]}, {"cell_type": "markdown", "metadata": {}, "source": ["But as discussed previously, that data is currently loaded *in memory* using Python, but we often want to be able to store things *on disk* using some kind of file.\n", "\n", "So first, we need to *serialize* the data in some way. Serialization means that we are converting the Python object into a structured format for storage and sharing. Let's serialize this list of lists so that:\n", "\n", "* the overall list is represented by a string\n", "* each nested list is on its own line of the string (i.e. separated by a newline)\n", "* each element within each nested list is separated by a comma"]}, {"cell_type": "code", "execution_count": 2, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["13.1,13.59,13.44\n", "13.93,13.85,13.47\n", "14.12,14.41,13.89\n", "14.42,13.55,13.43\n"]}], "source": ["# Initialize an empty string\n", "track_times_csv = \"\"\n", "\n", "# Loop over all lists in the overall list\n", "for index, athlete_times in enumerate(track_times):\n", "    # Join together the values in the nested list using\n", "    # a comma as a separator\n", "    athlete_times_string = \",\".join([str(time) for time in athlete_times])\n", "    # Append the values to the overall string\n", "    track_times_csv += athlete_times_string\n", "    # Append a newline, unless this is the last row\n", "    if index < (len(track_times) - 1):\n", "        track_times_csv += \"\\n\"\n", "    \n", "print(track_times_csv)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["...and that's it! That's a CSV.\n", "\n", "We can write it to a file like this:"]}, {"cell_type": "code", "execution_count": 3, "metadata": {}, "outputs": [], "source": ["with open(\"track_times.csv\", \"w\") as f:\n", "    f.write(track_times_csv)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Then later even if we restart the kernel, we can open up the file and deserialize the data back into a list of lists:"]}, {"cell_type": "code", "execution_count": 4, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["13.1,13.59,13.44\n", "13.93,13.85,13.47\n", "14.12,14.41,13.89\n", "14.42,13.55,13.43\n"]}], "source": ["with open(\"track_times.csv\") as f:\n", "    track_times_csv_from_disk = f.read()\n", "print(track_times_csv_from_disk)"]}, {"cell_type": "code", "execution_count": 5, "metadata": {}, "outputs": [{"data": {"text/plain": ["[[13.1, 13.59, 13.44],\n", " [13.93, 13.85, 13.47],\n", " [14.12, 14.41, 13.89],\n", " [14.42, 13.55, 13.43]]"]}, "execution_count": 5, "metadata": {}, "output_type": "execute_result"}], "source": ["track_times_from_disk = []\n", "for row in track_times_csv_from_disk.split(\"\\n\"):\n", "    times = [float(time) for time in row.split(\",\")]\n", "    track_times_from_disk.append(times)\n", "    \n", "track_times_from_disk"]}, {"cell_type": "markdown", "metadata": {}, "source": ["If we did everything correctly, this new list of lists should contain the exact same data as the original:"]}, {"cell_type": "code", "execution_count": 6, "metadata": {}, "outputs": [{"data": {"text/plain": ["True"]}, "execution_count": 6, "metadata": {}, "output_type": "execute_result"}], "source": ["track_times_from_disk == track_times"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Great!\n", "\n", "## `csv` Module\n", "\n", "That wasn't too bad, but in general you don't actually need to serialize and deserialize your data \"by hand\" like that. Instead, there is a module built in to Python called `csv` that can do the same thing using fewer lines of code! It also has helpful functionality for dealing with:\n", "\n", "* CSV files with headers that indicate what each column represents\n", "* More kinds of plain text delimited data, such as tab-separated values (TSV) files (where the delimiter is a tab `\\t` rather than a comma)\n", "* Properly handling text data inside a CSV, e.g. if your data contains the text `\"Hello, World!\"` you want to make sure that the `,` is treated as part of the contents of that cell, not treated as a delimiter separating the columns\n", "* Reading and writing CSV files that are compatible with spreadsheet software such as Excel\n", "\n", "You can find full documentation for this module [here](https://docs.python.org/3/library/csv.html).\n", "\n", "To use the `csv` module, start by importing it:"]}, {"cell_type": "code", "execution_count": 7, "metadata": {}, "outputs": [], "source": ["import csv"]}, {"cell_type": "markdown", "metadata": {}, "source": ["### `csv.reader`\n", "\n", "If we wanted to replicate the previous example of opening the track times CSV, this time using the `csv` module, that would look like this:"]}, {"cell_type": "code", "execution_count": 8, "metadata": {}, "outputs": [{"data": {"text/plain": ["[[13.1, 13.59, 13.44],\n", " [13.93, 13.85, 13.47],\n", " [14.12, 14.41, 13.89],\n", " [14.42, 13.55, 13.43]]"]}, "execution_count": 8, "metadata": {}, "output_type": "execute_result"}], "source": ["with open(\"track_times.csv\") as f:\n", "    # Pass the file in to a \"reader\" object and specify that\n", "    # values without explicit quotes (i.e. all values in this\n", "    # dataset) should be treated as numbers\n", "    reader = csv.reader(f, quoting=csv.QUOTE_NONNUMERIC)\n", "    # Get all of the data from the reader using `list`\n", "    track_times_with_csv_module = list(reader)\n", "    \n", "track_times_with_csv_module"]}, {"cell_type": "markdown", "metadata": {}, "source": ["We shortened the code reading the data from a file into a list of lists from 6 lines to 3, and all of it is quite simple (no joining, splitting, or list comprehensions). We could even shrink that to two lines (opening the file, then nesting `list(csv.reader(f, quoting=csv.QUOTE_NONNUMERIC))`). Nice!\n", "\n", "(Note: calling `list()` on the reader is important if you want to be able to use the data after the file is closed. Like we discussed previously relating to opening files in general, sometimes the tools do not assume that you want to read all of the file contents into memory at once, so you have to do this explicitly. If you do not call `list()`, the reader will allow you to read through the file one line at a time and will throw an error if the file is closed.)\n", "\n", "What we just used is the `csv.reader` object ([documentation here](https://docs.python.org/3/library/csv.html#csv.reader)), which is useful for CSVs without column headings like the one we created. It has a parallel `csv.writer` object ([documentation here](https://docs.python.org/3/library/csv.html#csv.writer)) that can take a list of lists and write it to a CSV file with similarly few lines of code.\n", "\n", "However most of the time you will be working with CSVs that have column headings, in which case the `csv.DictReader` is often more useful."]}, {"cell_type": "markdown", "metadata": {}, "source": ["### `csv.DictReader`\n", "\n", "Let's advance from a high school track dataset to a dataset with information about Olympic track and field medal-winners from [kaggle](https://www.kaggle.com/jayrav13/olympic-track-field-results). The first five rows look like this:\n", "\n", "| Gender | Event      | Location | Year | Medal | Name                  | Nationality | Result   |\n", "| ------ | ---------- | -------- | ---- | ----- | --------------------- | ----------- | -------- |\n", "| M      | 10000M Men | Rio      | 2016 | G     | Mohamed FARAH         | GBR         | 25:05.17 |\n", "| M      | 10000M Men | Rio      | 2016 | S     | Paul Kipngetich TANUI | KEN         | 27:05.64 |\n", "| M      | 10000M Men | Rio      | 2016 | B     | Tamirat TOLA          | ETH         | 27:06.26 |\n", "| M      | 10000M Men | Beijing  | 2008 | G     | Kenenisa BEKELE       | ETH         | 27:01.17 |\n", "| M      | 10000M Men | Beijing  | 2008 | S     | Sileshi SIHINE        | ETH         | 27:02.77 |\n", "\n", "Technically we could open this with `csv.reader`:"]}, {"cell_type": "code", "execution_count": 9, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["['Gender', 'Event', 'Location', 'Year', 'Medal', 'Name', 'Nationality', 'Result']\n", "['M', '10000M Men', 'Rio', '2016', 'G', 'Mohamed FARAH', 'GBR', '25:05.17']\n", "['M', '10000M Men', 'Rio', '2016', 'S', 'Paul Kipngetich TANUI', 'KEN', '27:05.64']\n", "['M', '10000M Men', 'Rio', '2016', 'B', 'Tamirat TOLA', 'ETH', '27:06.26']\n", "['M', '10000M Men', 'Beijing', '2008', 'G', 'Kenenisa BEKELE', 'ETH', '27:01.17']\n", "['M', '10000M Men', 'Beijing', '2008', 'S', 'Sileshi SIHINE', 'ETH', '27:02.77']\n"]}], "source": ["with open(\"olympic_medals.csv\") as f:\n", "    reader = csv.reader(f)\n", "    # Printing only the header and first 5 rows of data\n", "    for _ in range(6):\n", "        print(next(reader))"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Then we could use list indexing to access the gender field of a given row using `[0]` or the nationality field using `[-2]`. But you can see how that would create some hard-to-read and error-prone code!\n", "\n", "Fortunately we aren't limited to just using the `list` data structure \u2014 we can use a `dict` instead, so that we could look up the gender field using `[\"Gender\"]` or the nationality field using `[\"Nationality\"]`.\n", "\n", "In order to read the data in as a list of dictionaries rather than a list of lists, we can use `csv.DictReader`:"]}, {"cell_type": "code", "execution_count": 10, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Rio', 'Year': '2016', 'Medal': 'G', 'Name': 'Mohamed FARAH', 'Nationality': 'GBR', 'Result': '25:05.17'}\n", "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Rio', 'Year': '2016', 'Medal': 'S', 'Name': 'Paul Kipngetich TANUI', 'Nationality': 'KEN', 'Result': '27:05.64'}\n", "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Rio', 'Year': '2016', 'Medal': 'B', 'Name': 'Tamirat TOLA', 'Nationality': 'ETH', 'Result': '27:06.26'}\n", "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Beijing', 'Year': '2008', 'Medal': 'G', 'Name': 'Kenenisa BEKELE', 'Nationality': 'ETH', 'Result': '27:01.17'}\n", "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Beijing', 'Year': '2008', 'Medal': 'S', 'Name': 'Sileshi SIHINE', 'Nationality': 'ETH', 'Result': '27:02.77'}\n"]}], "source": ["with open(\"olympic_medals.csv\") as f:\n", "    reader = csv.DictReader(f)\n", "    olympics_data = list(reader)\n", "\n", "# Print the first 5 rows of data\n", "for index in range(5):\n", "    print(olympics_data[index])"]}, {"cell_type": "markdown", "metadata": {}, "source": ["The number of rows in the dataset is just the length of the resulting list:"]}, {"cell_type": "code", "execution_count": 11, "metadata": {}, "outputs": [{"data": {"text/plain": ["2394"]}, "execution_count": 11, "metadata": {}, "output_type": "execute_result"}], "source": ["len(olympics_data)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Now we can perform data analysis and cleaning tasks in a neater, clearer way.\n", "\n", "For example, if our task was ***filter the data so that it only includes gold medals***, that logic would look something like this:"]}, {"cell_type": "code", "execution_count": 12, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["Out of 2394 total medals, this dataset \n", "contains information about 799 gold medals\n"]}], "source": ["gold_medals = []\n", "\n", "for row in olympics_data:\n", "    if row[\"Medal\"] == \"G\":\n", "        gold_medals.append(row)\n", "        \n", "print(f\"\"\"Out of {len(olympics_data)} total medals, this dataset \n", "contains information about {len(gold_medals)} gold medals\"\"\")"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Or if it was ***for all USA gold medals in 2016, what were the events and the names of the athletes***, that logic would look something like this:"]}, {"cell_type": "code", "execution_count": 13, "metadata": {}, "outputs": [{"data": {"text/plain": ["[{'Event': '1500M Men', 'Name': 'Matthew CENTROWITZ'},\n", " {'Event': '400M Hurdles Men', 'Name': 'Kerron CLEMENT'},\n", " {'Event': '4X400M Relay Men', 'Name': 'null'},\n", " {'Event': 'Decathlon Men', 'Name': 'Ashton EATON'},\n", " {'Event': 'Long Jump Men', 'Name': 'Jeff HENDERSON'},\n", " {'Event': 'Shot Put Men', 'Name': 'Ryan CROUSER'},\n", " {'Event': 'Triple Jump Men', 'Name': 'Christian TAYLOR'},\n", " {'Event': '100M Hurdles Women', 'Name': 'Brianna ROLLINS'},\n", " {'Event': '400M Hurdles Women', 'Name': 'Dalilah MUHAMMAD'},\n", " {'Event': '4X100M Relay Women', 'Name': 'null'},\n", " {'Event': '4X400M Relay Women', 'Name': 'null'},\n", " {'Event': 'Long Jump Women', 'Name': 'Tianna BARTOLETTA'},\n", " {'Event': 'Shot Put Women', 'Name': 'Michelle CARTER'}]"]}, "execution_count": 13, "metadata": {}, "output_type": "execute_result"}], "source": ["usa_2016_gold_medals = []\n", "\n", "for row in olympics_data:\n", "    if row[\"Medal\"] == \"G\" and row[\"Nationality\"] == \"USA\" and row[\"Year\"] == \"2016\":\n", "        usa_2016_gold_medals.append({\"Event\": row[\"Event\"], \"Name\": row[\"Name\"]})\n", "        \n", "usa_2016_gold_medals"]}, {"cell_type": "markdown", "metadata": {}, "source": ["And we could write that result to a file using `csv.DictWriter` ([documentation here](https://docs.python.org/3/library/csv.html#csv.DictWriter)):"]}, {"cell_type": "code", "execution_count": 14, "metadata": {}, "outputs": [], "source": ["with open(\"usa_2016_gold_medals.csv\", \"w\") as f:\n", "    writer = csv.DictWriter(f, fieldnames=[\"Event\", \"Name\"])\n", "    writer.writeheader()\n", "    for row in usa_2016_gold_medals:\n", "        writer.writerow(row)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["We can use the bash command `cat` to visually inspect the file that was created:\n", "\n", "(If you are running this lesson on a Windows or other non-Unix computer, you may need to use some other tool to do this, or just skip this step since it is just for demonstration purposes.)"]}, {"cell_type": "code", "execution_count": 15, "metadata": {}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["Event,Name\r", "\r\n", "1500M Men,Matthew CENTROWITZ\r", "\r\n", "400M Hurdles Men,Kerron CLEMENT\r", "\r\n", "4X400M Relay Men,null\r", "\r\n", "Decathlon Men,Ashton EATON\r", "\r\n", "Long Jump Men,Jeff HENDERSON\r", "\r\n", "Shot Put Men,Ryan CROUSER\r", "\r\n", "Triple Jump Men,Christian TAYLOR\r", "\r\n", "100M Hurdles Women,Brianna ROLLINS\r", "\r\n", "400M Hurdles Women,Dalilah MUHAMMAD\r", "\r\n", "4X100M Relay Women,null\r", "\r\n", "4X400M Relay Women,null\r", "\r\n", "Long Jump Women,Tianna BARTOLETTA\r", "\r\n", "Shot Put Women,Michelle CARTER\r", "\r\n"]}], "source": ["! cat usa_2016_gold_medals.csv"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Data Schemas and CSV Files\n", "\n", "A data schema is, broadly, the structure that the data is stored in. As a part of the overall data science process, understanding the schema is an important element of **data understanding**.\n", "\n", "It includes some things that can be determined automatically/programmatically:\n", "\n", "* How many rows and columns are there?\n", "* What are the column names?\n", "* For a given column, what is the data type (e.g. string, integer, boolean)?\n", "* Is one of the columns a unique identifier for that record?\n", "* Which columns can contain missing data?\n", "\n", "Then there are other things that you might need additional documentation to determine:\n", "\n", "* What does a row (record) represent?\n", "* What does each column (feature) represent?\n", "* For a numeric column, what are the units (e.g. seconds, inches, kilograms)?\n", "\n", "When working with database tools like SQL, the schema is a formal attribute of the system that can be inspected. In the SQLite command-line interface, for example, the command is `.schema`, which will tell you the names of all tables and the data types of each of their columns. There can also be formal schemas in NoSQL (not only SQL) databases as well as JSON and XML file formats.\n", "\n", "When working with CSV files, understanding the schema is more ambiguous and open-ended. It's about getting yourself oriented to the overall structure of the data, and filling in the finer details as needed for the business problem.\n", "\n", "### Data Schema of the Olympic Medals Dataset\n", "\n", "Let's take the Olympic medals dataset we've been working with as an example.\n", "\n", "**Possibly the most important question to ask about any CSV dataset is:** ***What does a row represent?***\n", "\n", "This might seem extremely obvious but it can be important to make sure you understand the details.\n", "\n", "With this dataset, a row represents an Olympic medal win.\n", "\n", "It does *not* represent:\n", "\n", "* A country (the same country can appear multiple times if it has won medals in multiple years)\n", "* A type of Olympic track and field event (the same event name can appear multiple times if it happened in multiple years)\n", "* An Olympic athlete (the same athlete can appear multiple times if they have won multiple medals, and some rows are team events where the name is `null`)\n", "* The performance (\"Result\") of a given athlete in a given event in a given year, if that performance did not win a medal\n", "* etc.\n", "\n", "Therefore if you were trying to answer a question about a country, a type of event, or an athlete, you would need to perform some additional filtering and/or aggregation in order to form the correct units to answer that question.\n", "\n", "If you were trying to answer a question about the performance of athletes who did not win medals vs. those who did win medals, that would not be possible with this dataset, since this dataset only includes medal winners. It also would not allow you to answer questions about the performance of these athletes at these events outside of the Olympics (e.g. at the national championship level).\n", "\n", "Understanding what a row represents is crucial for being able to identify what questions you can and cannot answer with a given dataset.\n", "\n", "**What does each column represent?**\n", "\n", "To extract the basics of this information, you can just call the `.keys()` on one of the row dictionaries. In this case, the columns are:\n", "\n", "* `'Gender'`\n", "* `'Event'`\n", "* `'Location'`\n", "* `'Year'`\n", "* `'Medal'`\n", "* `'Name'`\n", "* `'Nationality'`\n", "* `'Result'`\n", "\n", "If you need to understand further details such as the capitalization style of the names or the units of the results, you can often find this information in documentation about the dataset. If not, you may need to apply your own judgment.\n", "\n", "For example, let's look at a record from this dataset:"]}, {"cell_type": "code", "execution_count": 16, "metadata": {}, "outputs": [{"data": {"text/plain": ["{'Gender': 'M',\n", " 'Event': '100M Men',\n", " 'Location': 'Montreal',\n", " 'Year': '1976',\n", " 'Medal': 'S',\n", " 'Name': 'Donald QUARRIE',\n", " 'Nationality': 'JAM',\n", " 'Result': '10.08'}"]}, "execution_count": 16, "metadata": {}, "output_type": "execute_result"}], "source": ["olympics_data[85]"]}, {"cell_type": "markdown", "metadata": {}, "source": ["What do we think are the units of the `Result` value?\n", "\n", "Well, if we look at the `Event` value, it is a 100 meter dash. That is a track event, so these are some kind of units of *time*.\n", "\n", "But are they hours? Minutes? Seconds?\n", "\n", "At this point if you are unsure, you could look up recent 100 meter dash times, or the world record best time for that event. (Although you'll want to watch out for older data like this \u2014 sometimes data from the '70s is going to have a significantly different scale compared to data from today!)\n", "\n", "With a bit of research, it's clear that the units are *seconds*.\n", "\n", "But what if we look at a different record:"]}, {"cell_type": "code", "execution_count": 17, "metadata": {}, "outputs": [{"data": {"text/plain": ["{'Gender': 'M',\n", " 'Event': 'Discus Throw Men',\n", " 'Location': 'Los Angeles',\n", " 'Year': '1984',\n", " 'Medal': 'B',\n", " 'Name': 'John POWELL',\n", " 'Nationality': 'USA',\n", " 'Result': '65.46'}"]}, "execution_count": 17, "metadata": {}, "output_type": "execute_result"}], "source": ["olympics_data[1100]"]}, {"cell_type": "markdown", "metadata": {}, "source": ["Is that `Result` also measured in seconds?\n", "\n", "No, this is a discus throw, which is a field event. The goal is not to finish in the least amount of time, it's to throw the discus as far as possible. So this is a unit of *distance*.\n", "\n", "If we look up some more information about this event, we find that the units are *meters*.\n", "\n", "It appears that the `Result` column contains different units depending on the event, which makes sense, since the result needed to win is different depending on the event.\n", "\n", "As you can see, this process can take a fair amount of time if you do not have domain knowledge related to the dataset. Sometimes it is a good strategy to learn more about the columns one at a time \u2014 only as you encounter business questions that seem related to them \u2014 rather than trying to understand all of the columns before performing any analysis."]}, {"cell_type": "markdown", "metadata": {}, "source": ["**Is there a unique identifier?**\n", "\n", "In some datasets, one of the columns is a unique identifier, also commonly shorted as just \"ID\" or \"id\".\n", "\n", "For example, if each record represented a country, there might be a unique identifier like `USA`, `KEN`, etc. Or a zip code for a geographical area or a social security number for a person. These unique identifiers are genuine features of the rows, and they can be helpful for merging datasets together by connecting a feature of one dataset to an identifier of another.\n", "\n", "In other cases, there are unique identifiers that are solely artifacts of the particular dataset and are not useful for merging. For example, if we went through all 2394 records in the Olympic medals dataset and assigned them IDs 0 through 2393, we would have a unique identifier, but it would not be a genuine feature of a given row and would not be useful for merging together additional data. SQL databases often have this type of unique identifier, called a \"primary key\".\n", "\n", "This dataset does not have a unique identifier, since almost all of the values appear more than once. There are multiple gold medals, multiple events from 2016, multiple men's events, etc. Nevertheless we could potentially merge it with other tables if *those* tables had one or more of these features. For example, we could add in the GDP of the athlete's home country for that year if we found a table of countries labeled similarly and their GDP by year."]}, {"cell_type": "markdown", "metadata": {}, "source": ["### Schemas Conclusion\n", "\n", "Now that you have the tools to start working with actual datasets, your tasks as a data scientist have expanded beyond just technical code implementation tasks into analysis tasks. Often there will not be a single \"right answer\" and you will need to contend with ambiguity and uncertainty about what is in your dataset and what questions you can answer.\n", "\n", "Considering the schema is a great place to start when answering these questions!\n", "\n", "One way to get more practice with this is open-ended data exploration. For example, check out [this website](https://dataportals.org/search) for a list of open data portals, many of which offer CSV data. You can even explore the collection of data portals programmatically using a [CSV](https://raw.githubusercontent.com/okfn/dataportals.org/master/data/portals.csv)!"]}, {"cell_type": "markdown", "metadata": {}, "source": ["## Summary\n", "\n", "In this lesson, you learned the basics of the CSV data format and looked at an example using pure Python to serialize data. Then you were introduced to the simpler, more sophisticated technique of using the `csv` module. Finally, you were introduced to some of the concepts of data schemas in general, how they apply to CSV formats, and what questions to ask when you encounter a new dataset."]}], "metadata": {"kernelspec": {"display_name": "Python (learn-env)", "language": "python", "name": "learn-env"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.8.5"}}, "nbformat": 4, "nbformat_minor": 4}
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# CSV"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "\n",
+    "In this lesson we will cover the CSV (comma-separated values) data format, one of the most simple and popular data serialization formats used in data science.\n",
+    "\n",
+    "## Objectives\n",
+    "\n",
+    "You will be able to:\n",
+    "\n",
+    "* Describe features of the CSV format and the Python `csv` module\n",
+    "* Use Python to read and parse data from CSV files\n",
+    "* Interpret the schemas of CSV files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## CSV Format\n",
+    "\n",
+    "The full name for this data format is \"comma-separated values\", but it is conventionally referred to by the shorthand \"CSV\"\n",
+    "\n",
+    "At a high level, this format is designed to contain tabular data (data represented by rows and columns), where each line of the file is a row, and each column of data within that row is separated by a comma.\n",
+    "\n",
+    "CSV is a **plain text**, **delimited** format, meaning its contents are essentially just strings with a specified structure. You can visually inspect the contents of plain text files using general-purpose text editing tools such as Vim, VS Code, or Notepad.  (This is in contrast to formats like images or SQLite databases, which contain encoded bytes that require specific tools to read.)\n",
+    "\n",
+    "Because of this, we can start digging in to how the CSV *format* works without actually using any CSV *files*. Instead we'll just start with some Python strings.\n",
+    "\n",
+    "Let's say we have this dataset representing the 100 meter dash times for 4 high school athletes across 3 track meets:\n",
+    "\n",
+    "| Meet 1 | Meet 2 | Meet 3 |\n",
+    "| ------ | ------ | ------ |\n",
+    "| 13.10  | 13.59  | 13.44  |\n",
+    "| 13.93  | 13.85  | 13.47  |\n",
+    "| 14.12  | 14.41  | 13.89  |\n",
+    "| 14.42  | 13.55  | 13.43  |\n",
+    "\n",
+    "If we wanted to represent that dataset in Python, we might do something like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[13.1, 13.59, 13.44],\n",
+       " [13.93, 13.85, 13.47],\n",
+       " [14.12, 14.41, 13.89],\n",
+       " [14.42, 13.55, 13.43]]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "track_times = [\n",
+    "    [13.10, 13.59, 13.44],\n",
+    "    [13.93, 13.85, 13.47],\n",
+    "    [14.12, 14.41, 13.89],\n",
+    "    [14.42, 13.55, 13.43]\n",
+    "]\n",
+    "track_times"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But as discussed previously, that data is currently loaded *in memory* using Python, but we often want to be able to store things *on disk* using some kind of file.\n",
+    "\n",
+    "So first, we need to *serialize* the data in some way. Serialization means that we are converting the Python object into a structured format for storage and sharing. Let's serialize this list of lists so that:\n",
+    "\n",
+    "* the overall list is represented by a string\n",
+    "* each nested list is on its own line of the string (i.e. separated by a newline)\n",
+    "* each element within each nested list is separated by a comma"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13.1,13.59,13.44\n",
+      "13.93,13.85,13.47\n",
+      "14.12,14.41,13.89\n",
+      "14.42,13.55,13.43\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Initialize an empty string\n",
+    "track_times_csv = \"\"\n",
+    "\n",
+    "# Loop over all lists in the overall list\n",
+    "for index, athlete_times in enumerate(track_times):\n",
+    "    # Join together the values in the nested list using\n",
+    "    # a comma as a separator\n",
+    "    athlete_times_string = \",\".join([str(time) for time in athlete_times])\n",
+    "    # Append the values to the overall string\n",
+    "    track_times_csv += athlete_times_string\n",
+    "    # Append a newline, unless this is the last row\n",
+    "    if index < (len(track_times) - 1):\n",
+    "        track_times_csv += \"\\n\"\n",
+    "    \n",
+    "print(track_times_csv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "...and that's it! That's a CSV.\n",
+    "\n",
+    "We can write it to a file like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"track_times.csv\", \"w\") as f:\n",
+    "    f.write(track_times_csv)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then later even if we restart the kernel, we can open up the file and deserialize the data back into a list of lists:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "13.1,13.59,13.44\n",
+      "13.93,13.85,13.47\n",
+      "14.12,14.41,13.89\n",
+      "14.42,13.55,13.43\n"
+     ]
+    }
+   ],
+   "source": [
+    "with open(\"track_times.csv\") as f:\n",
+    "    track_times_csv_from_disk = f.read()\n",
+    "print(track_times_csv_from_disk)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[13.1, 13.59, 13.44],\n",
+       " [13.93, 13.85, 13.47],\n",
+       " [14.12, 14.41, 13.89],\n",
+       " [14.42, 13.55, 13.43]]"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "track_times_from_disk = []\n",
+    "for row in track_times_csv_from_disk.split(\"\\n\"):\n",
+    "    times = [float(time) for time in row.split(\",\")]\n",
+    "    track_times_from_disk.append(times)\n",
+    "    \n",
+    "track_times_from_disk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we did everything correctly, this new list of lists should contain the exact same data as the original:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "track_times_from_disk == track_times"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Great!\n",
+    "\n",
+    "## `csv` Module\n",
+    "\n",
+    "That wasn't too bad, but in general you don't actually need to serialize and deserialize your data \"by hand\" like that. Instead, there is a module built in to Python called `csv` that can do the same thing using fewer lines of code! It also has helpful functionality for dealing with:\n",
+    "\n",
+    "* CSV files with headers that indicate what each column represents\n",
+    "* More kinds of plain text delimited data, such as tab-separated values (TSV) files (where the delimiter is a tab `\\t` rather than a comma)\n",
+    "* Properly handling text data inside a CSV, e.g. if your data contains the text `\"Hello, World!\"` you want to make sure that the `,` is treated as part of the contents of that cell, not treated as a delimiter separating the columns\n",
+    "* Reading and writing CSV files that are compatible with spreadsheet software such as Excel\n",
+    "\n",
+    "You can find full documentation for this module [here](https://docs.python.org/3/library/csv.html).\n",
+    "\n",
+    "To use the `csv` module, start by importing it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `csv.reader`\n",
+    "\n",
+    "If we wanted to replicate the previous example of opening the track times CSV, this time using the `csv` module, that would look like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[[13.1, 13.59, 13.44],\n",
+       " [13.93, 13.85, 13.47],\n",
+       " [14.12, 14.41, 13.89],\n",
+       " [14.42, 13.55, 13.43]]"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "with open(\"track_times.csv\") as f:\n",
+    "    # Pass the file in to a \"reader\" object and specify that\n",
+    "    # values without explicit quotes (i.e. all values in this\n",
+    "    # dataset) should be treated as numbers\n",
+    "    reader = csv.reader(f, quoting=csv.QUOTE_NONNUMERIC)\n",
+    "    # Get all of the data from the reader using `list`\n",
+    "    track_times_with_csv_module = list(reader)\n",
+    "    \n",
+    "track_times_with_csv_module\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Get content for csv.QUOTE_NONNUMERIC\n",
+    "print(csv.QUOTE_NONNUMERIC)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We shortened the code reading the data from a file into a list of lists from 6 lines to 3, and all of it is quite simple (no joining, splitting, or list comprehensions). We could even shrink that to two lines (opening the file, then nesting `list(csv.reader(f, quoting=csv.QUOTE_NONNUMERIC))`). Nice!\n",
+    "\n",
+    "(Note: calling `list()` on the reader is important if you want to be able to use the data after the file is closed. Like we discussed previously relating to opening files in general, sometimes the tools do not assume that you want to read all of the file contents into memory at once, so you have to do this explicitly. If you do not call `list()`, the reader will allow you to read through the file one line at a time and will throw an error if the file is closed.)\n",
+    "\n",
+    "What we just used is the `csv.reader` object ([documentation here](https://docs.python.org/3/library/csv.html#csv.reader)), which is useful for CSVs without column headings like the one we created. It has a parallel `csv.writer` object ([documentation here](https://docs.python.org/3/library/csv.html#csv.writer)) that can take a list of lists and write it to a CSV file with similarly few lines of code.\n",
+    "\n",
+    "However most of the time you will be working with CSVs that have column headings, in which case the `csv.DictReader` is often more useful."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### `csv.DictReader`\n",
+    "\n",
+    "Let's advance from a high school track dataset to a dataset with information about Olympic track and field medal-winners from [kaggle](https://www.kaggle.com/jayrav13/olympic-track-field-results). The first five rows look like this:\n",
+    "\n",
+    "| Gender | Event      | Location | Year | Medal | Name                  | Nationality | Result   |\n",
+    "| ------ | ---------- | -------- | ---- | ----- | --------------------- | ----------- | -------- |\n",
+    "| M      | 10000M Men | Rio      | 2016 | G     | Mohamed FARAH         | GBR         | 25:05.17 |\n",
+    "| M      | 10000M Men | Rio      | 2016 | S     | Paul Kipngetich TANUI | KEN         | 27:05.64 |\n",
+    "| M      | 10000M Men | Rio      | 2016 | B     | Tamirat TOLA          | ETH         | 27:06.26 |\n",
+    "| M      | 10000M Men | Beijing  | 2008 | G     | Kenenisa BEKELE       | ETH         | 27:01.17 |\n",
+    "| M      | 10000M Men | Beijing  | 2008 | S     | Sileshi SIHINE        | ETH         | 27:02.77 |\n",
+    "\n",
+    "Technically we could open this with `csv.reader`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<_csv.reader object at 0x000001B7511B9D00>\n",
+      "['Gender', 'Event', 'Location', 'Year', 'Medal', 'Name', 'Nationality', 'Result']\n",
+      "['M', '10000M Men', 'Rio', '2016', 'G', 'Mohamed FARAH', 'GBR', '25:05.17']\n",
+      "['M', '10000M Men', 'Rio', '2016', 'S', 'Paul Kipngetich TANUI', 'KEN', '27:05.64']\n",
+      "['M', '10000M Men', 'Rio', '2016', 'B', 'Tamirat TOLA', 'ETH', '27:06.26']\n",
+      "['M', '10000M Men', 'Beijing', '2008', 'G', 'Kenenisa BEKELE', 'ETH', '27:01.17']\n",
+      "['M', '10000M Men', 'Beijing', '2008', 'S', 'Sileshi SIHINE', 'ETH', '27:02.77']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# If this code is used on a Windows machine, then\n",
+    "# the'encoding' argument should be used and set for 'utf-8'.\n",
+    "# The default encoding on a Windows machine used in the US or Europe\n",
+    "# is Windows 1252, an 8-bit map, which does not contain all characters from\n",
+    "# file 'olympic_medals.csv'\n",
+    "with open(\"olympic_medals.csv\", encoding='utf-8') as f:\n",
+    "    reader = csv.reader(f)\n",
+    "    print(reader)\n",
+    "    # Printing only the header and first 5 rows of data\n",
+    "    for _ in range(6):\n",
+    "        print(next(reader))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we could use list indexing to access the gender field of a given row using `[0]` or the nationality field using `[-2]`. But you can see how that would create some hard-to-read and error-prone code!\n",
+    "\n",
+    "Fortunately we aren't limited to just using the `list` data structure — we can use a `dict` instead, so that we could look up the gender field using `[\"Gender\"]` or the nationality field using `[\"Nationality\"]`.\n",
+    "\n",
+    "In order to read the data in as a list of dictionaries rather than a list of lists, we can use `csv.DictReader`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Rio', 'Year': '2016', 'Medal': 'G', 'Name': 'Mohamed FARAH', 'Nationality': 'GBR', 'Result': '25:05.17'}\n",
+      "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Rio', 'Year': '2016', 'Medal': 'S', 'Name': 'Paul Kipngetich TANUI', 'Nationality': 'KEN', 'Result': '27:05.64'}\n",
+      "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Rio', 'Year': '2016', 'Medal': 'B', 'Name': 'Tamirat TOLA', 'Nationality': 'ETH', 'Result': '27:06.26'}\n",
+      "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Beijing', 'Year': '2008', 'Medal': 'G', 'Name': 'Kenenisa BEKELE', 'Nationality': 'ETH', 'Result': '27:01.17'}\n",
+      "{'Gender': 'M', 'Event': '10000M Men', 'Location': 'Beijing', 'Year': '2008', 'Medal': 'S', 'Name': 'Sileshi SIHINE', 'Nationality': 'ETH', 'Result': '27:02.77'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# See comments in the immediately preceeding code cell\n",
+    "with open(\"olympic_medals.csv\", encoding='utf-8') as f:\n",
+    "    reader = csv.DictReader(f)\n",
+    "    olympics_data = list(reader)\n",
+    "\n",
+    "# Print the first 5 rows of data\n",
+    "for index in range(5):\n",
+    "    print(olympics_data[index])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The number of rows in the dataset is just the length of the resulting list:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2394"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(olympics_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can perform data analysis and cleaning tasks in a neater, clearer way.\n",
+    "\n",
+    "For example, if our task was ***filter the data so that it only includes gold medals***, that logic would look something like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Out of 2394 total medals, this dataset \n",
+      "contains information about 799 gold medals\n"
+     ]
+    }
+   ],
+   "source": [
+    "gold_medals = []\n",
+    "\n",
+    "for row in olympics_data:\n",
+    "    if row[\"Medal\"] == \"G\":\n",
+    "        gold_medals.append(row)\n",
+    "        \n",
+    "print(f\"\"\"Out of {len(olympics_data)} total medals, this dataset \n",
+    "contains information about {len(gold_medals)} gold medals\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or if it was ***for all USA gold medals in 2016, what were the events and the names of the athletes***, that logic would look something like this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'Event': '1500M Men', 'Name': 'Matthew CENTROWITZ'},\n",
+       " {'Event': '400M Hurdles Men', 'Name': 'Kerron CLEMENT'},\n",
+       " {'Event': '4X400M Relay Men', 'Name': 'null'},\n",
+       " {'Event': 'Decathlon Men', 'Name': 'Ashton EATON'},\n",
+       " {'Event': 'Long Jump Men', 'Name': 'Jeff HENDERSON'},\n",
+       " {'Event': 'Shot Put Men', 'Name': 'Ryan CROUSER'},\n",
+       " {'Event': 'Triple Jump Men', 'Name': 'Christian TAYLOR'},\n",
+       " {'Event': '100M Hurdles Women', 'Name': 'Brianna ROLLINS'},\n",
+       " {'Event': '400M Hurdles Women', 'Name': 'Dalilah MUHAMMAD'},\n",
+       " {'Event': '4X100M Relay Women', 'Name': 'null'},\n",
+       " {'Event': '4X400M Relay Women', 'Name': 'null'},\n",
+       " {'Event': 'Long Jump Women', 'Name': 'Tianna BARTOLETTA'},\n",
+       " {'Event': 'Shot Put Women', 'Name': 'Michelle CARTER'}]"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "usa_2016_gold_medals = []\n",
+    "\n",
+    "for row in olympics_data:\n",
+    "    if row[\"Medal\"] == \"G\" and row[\"Nationality\"] == \"USA\" and row[\"Year\"] == \"2016\":\n",
+    "        usa_2016_gold_medals.append({\"Event\": row[\"Event\"], \"Name\": row[\"Name\"]})\n",
+    "        \n",
+    "usa_2016_gold_medals"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And we could write that result to a file using `csv.DictWriter` ([documentation here](https://docs.python.org/3/library/csv.html#csv.DictWriter)):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using 'dialect' argument set to 'unix' avoids an extra empty line \n",
+    "# between rows of output\n",
+    "with open(\"usa_2016_gold_medals.csv\", \"w\") as f:\n",
+    "    writer = csv.DictWriter(f, fieldnames=[\"Event\", \"Name\"], dialect='unix')\n",
+    "    writer.writeheader()\n",
+    "    for row in usa_2016_gold_medals:\n",
+    "        writer.writerow(row)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the bash command `cat` to visually inspect the file that was created:\n",
+    "\n",
+    "(If you are running this lesson on a Windows or other non-Unix computer, you may need to use some other tool to do this, or just skip this step since it is just for demonstration purposes.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\"Event\",\"Name\"\n",
+      "\"1500M Men\",\"Matthew CENTROWITZ\"\n",
+      "\"400M Hurdles Men\",\"Kerron CLEMENT\"\n",
+      "\"4X400M Relay Men\",\"null\"\n",
+      "\"Decathlon Men\",\"Ashton EATON\"\n",
+      "\"Long Jump Men\",\"Jeff HENDERSON\"\n",
+      "\"Shot Put Men\",\"Ryan CROUSER\"\n",
+      "\"Triple Jump Men\",\"Christian TAYLOR\"\n",
+      "\"100M Hurdles Women\",\"Brianna ROLLINS\"\n",
+      "\"400M Hurdles Women\",\"Dalilah MUHAMMAD\"\n",
+      "\"4X100M Relay Women\",\"null\"\n",
+      "\"4X400M Relay Women\",\"null\"\n",
+      "\"Long Jump Women\",\"Tianna BARTOLETTA\"\n",
+      "\"Shot Put Women\",\"Michelle CARTER\"\n"
+     ]
+    }
+   ],
+   "source": [
+    "! cat usa_2016_gold_medals.csv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data Schemas and CSV Files\n",
+    "\n",
+    "A data schema is, broadly, the structure that the data is stored in. As a part of the overall data science process, understanding the schema is an important element of **data understanding**.\n",
+    "\n",
+    "It includes some things that can be determined automatically/programmatically:\n",
+    "\n",
+    "* How many rows and columns are there?\n",
+    "* What are the column names?\n",
+    "* For a given column, what is the data type (e.g. string, integer, boolean)?\n",
+    "* Is one of the columns a unique identifier for that record?\n",
+    "* Which columns can contain missing data?\n",
+    "\n",
+    "Then there are other things that you might need additional documentation to determine:\n",
+    "\n",
+    "* What does a row (record) represent?\n",
+    "* What does each column (feature) represent?\n",
+    "* For a numeric column, what are the units (e.g. seconds, inches, kilograms)?\n",
+    "\n",
+    "When working with database tools like SQL, the schema is a formal attribute of the system that can be inspected. In the SQLite command-line interface, for example, the command is `.schema`, which will tell you the names of all tables and the data types of each of their columns. There can also be formal schemas in NoSQL (not only SQL) databases as well as JSON and XML file formats.\n",
+    "\n",
+    "When working with CSV files, understanding the schema is more ambiguous and open-ended. It's about getting yourself oriented to the overall structure of the data, and filling in the finer details as needed for the business problem.\n",
+    "\n",
+    "### Data Schema of the Olympic Medals Dataset\n",
+    "\n",
+    "Let's take the Olympic medals dataset we've been working with as an example.\n",
+    "\n",
+    "**Possibly the most important question to ask about any CSV dataset is:** ***What does a row represent?***\n",
+    "\n",
+    "This might seem extremely obvious but it can be important to make sure you understand the details.\n",
+    "\n",
+    "With this dataset, a row represents an Olympic medal win.\n",
+    "\n",
+    "It does *not* represent:\n",
+    "\n",
+    "* A country (the same country can appear multiple times if it has won medals in multiple years)\n",
+    "* A type of Olympic track and field event (the same event name can appear multiple times if it happened in multiple years)\n",
+    "* An Olympic athlete (the same athlete can appear multiple times if they have won multiple medals, and some rows are team events where the name is `null`)\n",
+    "* The performance (\"Result\") of a given athlete in a given event in a given year, if that performance did not win a medal\n",
+    "* etc.\n",
+    "\n",
+    "Therefore if you were trying to answer a question about a country, a type of event, or an athlete, you would need to perform some additional filtering and/or aggregation in order to form the correct units to answer that question.\n",
+    "\n",
+    "If you were trying to answer a question about the performance of athletes who did not win medals vs. those who did win medals, that would not be possible with this dataset, since this dataset only includes medal winners. It also would not allow you to answer questions about the performance of these athletes at these events outside of the Olympics (e.g. at the national championship level).\n",
+    "\n",
+    "Understanding what a row represents is crucial for being able to identify what questions you can and cannot answer with a given dataset.\n",
+    "\n",
+    "**What does each column represent?**\n",
+    "\n",
+    "To extract the basics of this information, you can just call the `.keys()` on one of the row dictionaries. In this case, the columns are:\n",
+    "\n",
+    "* `'Gender'`\n",
+    "* `'Event'`\n",
+    "* `'Location'`\n",
+    "* `'Year'`\n",
+    "* `'Medal'`\n",
+    "* `'Name'`\n",
+    "* `'Nationality'`\n",
+    "* `'Result'`\n",
+    "\n",
+    "If you need to understand further details such as the capitalization style of the names or the units of the results, you can often find this information in documentation about the dataset. If not, you may need to apply your own judgment.\n",
+    "\n",
+    "For example, let's look at a record from this dataset:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Gender': 'M',\n",
+       " 'Event': '100M Men',\n",
+       " 'Location': 'Montreal',\n",
+       " 'Year': '1976',\n",
+       " 'Medal': 'S',\n",
+       " 'Name': 'Donald QUARRIE',\n",
+       " 'Nationality': 'JAM',\n",
+       " 'Result': '10.08'}"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "olympics_data[85]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What do we think are the units of the `Result` value?\n",
+    "\n",
+    "Well, if we look at the `Event` value, it is a 100 meter dash. That is a track event, so these are some kind of units of *time*.\n",
+    "\n",
+    "But are they hours? Minutes? Seconds?\n",
+    "\n",
+    "At this point if you are unsure, you could look up recent 100 meter dash times, or the world record best time for that event. (Although you'll want to watch out for older data like this — sometimes data from the '70s is going to have a significantly different scale compared to data from today!)\n",
+    "\n",
+    "With a bit of research, it's clear that the units are *seconds*.\n",
+    "\n",
+    "But what if we look at a different record:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Gender': 'M',\n",
+       " 'Event': 'Discus Throw Men',\n",
+       " 'Location': 'Los Angeles',\n",
+       " 'Year': '1984',\n",
+       " 'Medal': 'B',\n",
+       " 'Name': 'John POWELL',\n",
+       " 'Nationality': 'USA',\n",
+       " 'Result': '65.46'}"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "olympics_data[1100]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Is that `Result` also measured in seconds?\n",
+    "\n",
+    "No, this is a discus throw, which is a field event. The goal is not to finish in the least amount of time, it's to throw the discus as far as possible. So this is a unit of *distance*.\n",
+    "\n",
+    "If we look up some more information about this event, we find that the units are *meters*.\n",
+    "\n",
+    "It appears that the `Result` column contains different units depending on the event, which makes sense, since the result needed to win is different depending on the event.\n",
+    "\n",
+    "As you can see, this process can take a fair amount of time if you do not have domain knowledge related to the dataset. Sometimes it is a good strategy to learn more about the columns one at a time — only as you encounter business questions that seem related to them — rather than trying to understand all of the columns before performing any analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Is there a unique identifier?**\n",
+    "\n",
+    "In some datasets, one of the columns is a unique identifier, also commonly shorted as just \"ID\" or \"id\".\n",
+    "\n",
+    "For example, if each record represented a country, there might be a unique identifier like `USA`, `KEN`, etc. Or a zip code for a geographical area or a social security number for a person. These unique identifiers are genuine features of the rows, and they can be helpful for merging datasets together by connecting a feature of one dataset to an identifier of another.\n",
+    "\n",
+    "In other cases, there are unique identifiers that are solely artifacts of the particular dataset and are not useful for merging. For example, if we went through all 2394 records in the Olympic medals dataset and assigned them IDs 0 through 2393, we would have a unique identifier, but it would not be a genuine feature of a given row and would not be useful for merging together additional data. SQL databases often have this type of unique identifier, called a \"primary key\".\n",
+    "\n",
+    "This dataset does not have a unique identifier, since almost all of the values appear more than once. There are multiple gold medals, multiple events from 2016, multiple men's events, etc. Nevertheless we could potentially merge it with other tables if *those* tables had one or more of these features. For example, we could add in the GDP of the athlete's home country for that year if we found a table of countries labeled similarly and their GDP by year."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Schemas Conclusion\n",
+    "\n",
+    "Now that you have the tools to start working with actual datasets, your tasks as a data scientist have expanded beyond just technical code implementation tasks into analysis tasks. Often there will not be a single \"right answer\" and you will need to contend with ambiguity and uncertainty about what is in your dataset and what questions you can answer.\n",
+    "\n",
+    "Considering the schema is a great place to start when answering these questions!\n",
+    "\n",
+    "One way to get more practice with this is open-ended data exploration. For example, check out [this website](https://dataportals.org/search) for a list of open data portals, many of which offer CSV data. You can even explore the collection of data portals programmatically using a [CSV](https://raw.githubusercontent.com/okfn/dataportals.org/master/data/portals.csv)!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "In this lesson, you learned the basics of the CSV data format and looked at an example using pure Python to serialize data. Then you were introduced to the simpler, more sophisticated technique of using the `csv` module. Finally, you were introduced to some of the concepts of data schemas in general, how they apply to CSV formats, and what questions to ask when you encounter a new dataset."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python (learn-env)",
+   "language": "python",
+   "name": "learn-env"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Olympic medals dataset is encoded  in utf-8. A windows machine can't read it unless open() is provided with the argument 'encoding' set to value 'utf-8'.

For the same reason, csv.DictWriter() needs the argument 'dialect' supplied set to the value 'unix' to avoid an extra empty row.